### PR TITLE
Add catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: aws-lambda-utils-python
+  description: A description about this project
+spec:
+  type: unknown
+  owner: group:group-finance-innovation
+  lifecycle: production


### PR DESCRIPTION
# Add catalog-info.yaml to show the application in backstage.
## Important
The kind is set as **Component** but you can change it (see all [here](https://backstage.io/docs/features/software-catalog/descriptor-format))
Change the type "unknown" to the correct one (ex: **website** or **service**).
Change the "lifecycle" to correct one (**production**, **experimental**, **deprecated**)
If the application is from another owner, update the owner.
You can find the owners in [backstage](https://backstage.devtools.loft-prod.io/catalog?filters%5Bkind%5D=group&filters%5Buser%5D=all) (VPN required).
## More Information
https://loftbr.atlassian.net/wiki/spaces/ROAD/pages/2605809871/Backstage
## Support
Any questions: access the channel #squad_devtools.